### PR TITLE
update theme in documentation configuration

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
-theme: jekyll-theme-minimal
+theme: jekyll-theme-cayman
 title: "dputils Documentation"
 description: "Documentation for dputils"


### PR DESCRIPTION
This pull request includes a change to the `docs/_config.yml` file to update the theme used for the documentation.

* [`docs/_config.yml`](diffhunk://#diff-f64371f310bcd3bbf6ead5827d929a4eb13b7516806d6658485a996e39eb2556L1-R1): Changed the theme from `jekyll-theme-minimal` to `jekyll-theme-cayman`.